### PR TITLE
Add settings sheet for editor menus

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,7 @@
 import { ModeToggle } from "@/components/mode-toggle";
 import Tiptap from "@/components/tiptap";
+import EditorSettings from "@/components/editor-settings";
+import { useState } from "react";
 
 const sampleContent = `
   <h1>Welcome to the Tiptap Editor</h1>
@@ -12,13 +14,26 @@ const sampleContent = `
 `
 
 export default function Home() {
+  const [showFixedMenu, setShowFixedMenu] = useState(true)
+  const [showBubbleMenu, setShowBubbleMenu] = useState(true)
+
   return (
     <div className="flex flex-col h-screen">
-      <div className="flex justify-end p-4">
+      <div className="flex justify-end gap-2 p-4">
+        <EditorSettings
+          showFixedMenu={showFixedMenu}
+          setShowFixedMenu={setShowFixedMenu}
+          showBubbleMenu={showBubbleMenu}
+          setShowBubbleMenu={setShowBubbleMenu}
+        />
         <ModeToggle />
-      </div> 
+      </div>
       <div className="space-y-4 mx-4 md:mx-auto md:w-2xl">
-        <Tiptap content={sampleContent} />
+        <Tiptap
+          content={sampleContent}
+          showFixedMenu={showFixedMenu}
+          showBubbleMenu={showBubbleMenu}
+        />
       </div>
     </div>
   );

--- a/src/components/editor-settings.tsx
+++ b/src/components/editor-settings.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { Settings } from 'lucide-react'
+import { Sheet, SheetTrigger, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet'
+import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
+
+interface EditorSettingsProps {
+  showFixedMenu: boolean
+  setShowFixedMenu: (value: boolean) => void
+  showBubbleMenu: boolean
+  setShowBubbleMenu: (value: boolean) => void
+}
+
+export default function EditorSettings({
+  showFixedMenu,
+  setShowFixedMenu,
+  showBubbleMenu,
+  setShowBubbleMenu,
+}: EditorSettingsProps) {
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant='ghost' size='icon'>
+          <Settings className='size-4' />
+          <span className='sr-only'>Editor settings</span>
+        </Button>
+      </SheetTrigger>
+      <SheetContent side='right'>
+        <SheetHeader>
+          <SheetTitle>Editor settings</SheetTitle>
+          <SheetDescription>Toggle editor menus</SheetDescription>
+        </SheetHeader>
+        <div className='flex items-center justify-between p-4'>
+          <span>Fixed menu</span>
+          <Switch checked={showFixedMenu} onCheckedChange={setShowFixedMenu} />
+        </div>
+        <div className='flex items-center justify-between p-4'>
+          <span>Bubble menu</span>
+          <Switch checked={showBubbleMenu} onCheckedChange={setShowBubbleMenu} />
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}


### PR DESCRIPTION
## Summary
- add `EditorSettings` sheet component
- enable toggling of Tiptap fixed and bubble menus via the new sheet

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518caf03a8832fb987597407a09023